### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ environment:
   sdk: ">=2.0.0 <3.0.0"
 homepage: https://github.com/angel-dart/static
 author: Tobe O <thosakwe@gmail.com>
-version: 2.1.3+1
+version: 2.1.3+2
 dependencies:
   angel_framework: ^2.0.0-rc.0
   convert: ^2.0.0


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900